### PR TITLE
dont output relation errors to generated code

### DIFF
--- a/crud/Generator.php
+++ b/crud/Generator.php
@@ -288,7 +288,7 @@ class Generator extends \yii\gii\generators\crud\Generator
                     }
                 }
             } catch (Exception $e) {
-                echo "Error: " . $e->getMessage();
+                //echo "Error: " . $e->getMessage();
             }
         }
         return $stack;

--- a/crud/Generator.php
+++ b/crud/Generator.php
@@ -288,7 +288,7 @@ class Generator extends \yii\gii\generators\crud\Generator
                     }
                 }
             } catch (Exception $e) {
-                //echo "Error finding relation using " . get_class($model) . "::" . $method->name . ": " . $e->getMessage();
+                //echo "Error finding relation using " . get_class($model) . "::" . $method->name . "(): " . $e->getMessage();
             }
         }
         return $stack;

--- a/crud/Generator.php
+++ b/crud/Generator.php
@@ -288,7 +288,7 @@ class Generator extends \yii\gii\generators\crud\Generator
                     }
                 }
             } catch (Exception $e) {
-                //echo "Error: " . $e->getMessage();
+                //echo "Error finding relation using " . get_class($model) . "::" . $method->name . ": " . $e->getMessage();
             }
         }
         return $stack;


### PR DESCRIPTION
In this example RelationProvider calls all the getters, and if `Item::getItemByName()` is called with a null `$name` then it throws a DB exception.  

This is fine because it should never be called.

We have added a check at the top of the method so that it will simply return false, however this was hard to trace as to why the error was there in the first place, and why the error was output to the generated code.

My suggestion is to not echo the exception message into the generated code.

OR, perhaps if you really want to echo the message it would be nice if it had more information, for example output the model and method that caused the error.

```php
class Item extends ItemBase
{

    public static function getItemByName($name)
    {
        $item = Item::find()->where(['name' => $name])->one();
        if (!$item) {
            $item = new Item();
            $item->name = $name;
            $item->save(false);
        }
        return $item;
    }

}
```


```
Exception 'yii\db\IntegrityException' with message 'SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'name' cannot be null
The SQL being executed was: INSERT INTO `item` (`name`) VALUES (NULL)'
 
in /app/vendor/yiisoft/yii2/db/Schema.php:595
 
Error Info:
Array
(
    [0] => 23000
    [1] => 1048
    [2] => Column 'name' cannot be null
)
 
Stack trace:
#0 /app/vendor/yiisoft/yii2/db/Command.php(779): yii\db\Schema->convertException(Object(PDOException), 'INSERT INTO `it...')
#1 /app/vendor/yiisoft/yii2/db/Schema.php(415): yii\db\Command->execute()
#2 /app/vendor/yiisoft/yii2/db/ActiveRecord.php(457): yii\db\Schema->insert('item', Array)
#3 /app/vendor/yiisoft/yii2/db/ActiveRecord.php(422): yii\db\ActiveRecord->insertInternal(NULL)
#4 /app/vendor/yiisoft/yii2/db/BaseActiveRecord.php(589): yii\db\ActiveRecord->insert(false, NULL)
#5 /app/models/Item.php(23): yii\db\BaseActiveRecord->save(false)
#6 [internal function]: app\models\Item->getItemByName()
#7 /app/vendor/schmunk42/yii2-giiant/crud/Generator.php(280): call_user_func(Array)
#8 /app/vendor/schmunk42/yii2-giiant/crud/Generator.php(233): schmunk42\giiant\crud\Generator->getModelRelations('app\models\Item')
#9 /app/vendor/schmunk42/yii2-giiant/crud/providers/RelationProvider.php(33): schmunk42\giiant\crud\Generator->getRelationByColumn('app\models\Item', Object(yii\db\ColumnSchema))
#10 [internal function]: schmunk42\giiant\crud\providers\RelationProvider->activeField(Object(yii\db\ColumnSchema), Object(app\models\Item))
#11 /app/vendor/schmunk42/yii2-giiant/crud/Generator.php(500): call_user_func_array(Array, Array)
#12 /app/vendor/schmunk42/yii2-giiant/crud/Generator.php(334): schmunk42\giiant\crud\Generator->callProviderQueue('activeField', Object(yii\db\ColumnSchema), Object(app\models\Item))
#13 /app/vendor/cornernote/yii2-gii-tools/giiant/crud/gii-tools/views/_form.php(56): schmunk42\giiant\crud\Generator->activeField(Object(yii\db\ColumnSchema), Object(app\models\Item))
#14 /app/vendor/yiisoft/yii2/base/View.php(325): require('/vagrant/hanu_c...')
#15 /app/vendor/yiisoft/yii2/base/View.php(247): yii\base\View->renderPhpFile('/vagrant/hanu_c...', Array)
#16 /app/vendor/yiisoft/yii2-gii/Generator.php(317): yii\base\View->renderFile('/vagrant/hanu_c...', Array, Object(schmunk42\giiant\crud\Generator))
#17 /app/vendor/yiisoft/yii2-gii/generators/crud/Generator.php(173): yii\gii\Generator->render('views/_form.php')
#18 /app/vendor/yiisoft/yii2-gii/console/GenerateAction.php(52): yii\gii\generators\crud\Generator->generate()
#19 /app/vendor/yiisoft/yii2-gii/console/GenerateAction.php(35): yii\gii\console\GenerateAction->generateCode()
#20 [internal function]: yii\gii\console\GenerateAction->run()
#21 /app/vendor/yiisoft/yii2/base/Action.php(92): call_user_func_array(Array, Array)
#22 /app/vendor/yiisoft/yii2/base/Controller.php(151): yii\base\Action->runWithParams(Array)
#23 /app/vendor/yiisoft/yii2/console/Controller.php(91): yii\base\Controller->runAction('giiant-crud', Array)
#24 /app/vendor/yiisoft/yii2/base/Module.php(455): yii\console\Controller->runAction('giiant-crud', Array)
#25 /app/vendor/yiisoft/yii2/console/Application.php(161): yii\base\Module->runAction('gii/giiant-crud', Array)
#26 /app/vendor/cornernote/yii2-gii-tools/commands/BatchController.php(116): yii\console\Application->runAction('gii/giiant-crud', Array)
#27 /app/vendor/schmunk42/yii2-giiant/commands/BatchController.php(169): cornernote\giitools\commands\BatchController->actionCruds()
#28 [internal function]: schmunk42\giiant\commands\BatchController->actionIndex()
#29 /app/vendor/yiisoft/yii2/base/InlineAction.php(55): call_user_func_array(Array, Array)
#30 /app/vendor/yiisoft/yii2/base/Controller.php(151): yii\base\InlineAction->runWithParams(Array)
#31 /app/vendor/yiisoft/yii2/console/Controller.php(91): yii\base\Controller->runAction('', Array)
#32 /app/vendor/yiisoft/yii2/base/Module.php(455): yii\console\Controller->runAction('', Array)
#33 /app/vendor/yiisoft/yii2/console/Application.php(161): yii\base\Module->runAction('gii-tools-batch', Array)
#34 /app/vendor/yiisoft/yii2/console/Application.php(137): yii\console\Application->runAction('gii-tools-batch', Array)
#35 /app/vendor/yiisoft/yii2/base/Application.php(375): yii\console\Application->handleRequest(Object(yii\console\Request))
#36 /app/yii(27): yii\base\Application->run()
#37 {main}
```