### PR TITLE
Added UploadProvider to handle fields that contain paths to files.

### DIFF
--- a/crud/Generator.php
+++ b/crud/Generator.php
@@ -64,6 +64,11 @@ class Generator extends \yii\gii\generators\crud\Generator
      * @var array array of composer packages (only to show information to the developer in the web UI)
      */
     public $requires = [];
+    /**
+     * @var array array of strings that database field name contains to indicate is a file path. Regex will be:
+     *          "/(" . implode('|', {fileFieldMatches}) . ")/mi"
+     */
+    public $fileFieldMatches = "filename,file,path";
 
     private $_p = [];
 
@@ -129,8 +134,9 @@ class Generator extends \yii\gii\generators\crud\Generator
             parent::hints(),
             [
                 'providerList' => 'Comma separated list of provider class names, make sure you are using the full namespaced path <code>app\providers\CustomProvider1,<br/>app\providers\CustomProvider2</code>.',
-                'viewPath'     => 'Output path for view files, eg. <code>@backend/views/crud</code>.',
-                'pathPrefix'   => 'Customized route/subfolder for controllers and views eg. <code>crud/</code>. <b>Note!</b> Should correspond to <code>viewPath</code>.',
+                'viewPath' => 'Output path for view files, eg. <code>@backend/views/crud</code>.',
+                'pathPrefix' => 'Customized route/subfolder for controllers and views eg. <code>crud/</code>. <b>Note!</b> Should correspond to <code>viewPath</code>.',
+                'fileFieldMatches' => 'Comma separated list of strings that will be matched against column names in order to apply <code>app\providers\UploadProvider</code>. eg. <code>foo,bar</code> will generate an upload field for columns with names matching the regex <code>/(foo|bar)/mi</code>',
             ]
         );
     }
@@ -144,6 +150,7 @@ class Generator extends \yii\gii\generators\crud\Generator
             parent::rules(),
             [
                 [['providerList'], 'filter', 'filter' => 'trim'],
+                [['fileFieldMatches'], 'filter', 'filter' => 'trim'],
                 [['actionButtonClass', 'viewPath', 'pathPrefix'], 'safe'],
                 [['viewPath'], 'required'],
             ]

--- a/crud/form.php
+++ b/crud/form.php
@@ -33,3 +33,4 @@ echo $form->field($generator, 'actionButtonClass')->dropDownList(
     ]
 );
 echo $form->field($generator, 'providerList')->textarea();
+echo $form->field($generator, 'fileFieldMatches');

--- a/crud/providers/UploadProvider.php
+++ b/crud/providers/UploadProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace schmunk42\giiant\crud\providers;
+
+use yii\db\Schema;
+
+class UploadProvider extends \schmunk42\giiant\base\Provider
+{
+    public function activeField($attribute)
+    {
+        // TODO: internationalization
+
+        if (!isset($this->generator->getTableSchema()->columns[$attribute])) {
+            return null;
+        }
+
+        $column = $this->generator->getTableSchema()->columns[$attribute];
+
+        switch ($column->type) {
+            case Schema::TYPE_STRING:
+            case Schema::TYPE_TEXT:
+                $fileFieldMatches = $this->generator->fileFieldMatches;
+
+                if (!empty($fileFieldMatches)) {
+                    $fileFieldMatches = explode(',', preg_replace('/\s+/', '', $fileFieldMatches));
+
+                    if (!empty($fileFieldMatches)) {
+                        $regex = "/(" . implode('|', $fileFieldMatches) . ")/mi";
+
+                        if (preg_match($regex, $column->name)) {
+                            $msg = '2amigos/yii2-file-upload-widget';
+
+                            if (!in_array($msg, $this->generator->requires)) {
+                                $this->generator->requires[] = $msg;
+                            }
+
+                            return "\$form->field(\$model, '{$column->name}')->widget(dosamigos\\fileupload\\FileUpload::className(), [
+    'url' => [''],      // current requested URL. This will be passed as input to function yii\\helpers\\BaseUrl::to()
+    'plus' => true,
+    'options' => [
+        // HTML attributes. Example:
+        // 'accept' => 'image/*'
+    ],
+    'clientOptions' => [
+        // options @ https://github.com/blueimp/jQuery-File-Upload/wiki/Options
+        'maxFileSize' => 2000000    // 2 Mb
+    ],
+    //'clientEvents' => [
+    //    // callbacks @ https://github.com/blueimp/jQuery-File-Upload/wiki/Options#callback-options
+    //],
+]);
+";
+                        }
+                    }
+
+                }
+
+
+
+
+            default:
+                return null;
+        }
+    }
+}


### PR DESCRIPTION
A provider has been added to handles fields containing paths to files. By default columns which names contain filename, file or path will be considered as upload fields. This can be modified in the new form field "File Field Matches".

#### WARNING!
This pull request should not be merged until issues 2amigos/yii2-file-upload-widget#47 and 2amigos/yii2-file-upload-widget#37 have been fixed. Right now is not functional!
