### PR TITLE
Corrected Ns-Handling in Template

### DIFF
--- a/src/generators/crud/default/controller-extended.php
+++ b/src/generators/crud/default/controller-extended.php
@@ -10,7 +10,7 @@ namespace <?= \yii\helpers\StringHelper::dirname(ltrim($generator->controllerCla
 /**
 * This is the class for controller "<?= $controllerClassName ?>".
 */
-class <?= $controllerClassName ?> extends \<?= $generator->controllerNs.'\base\\'.$controllerClassName."\n" ?>
+class <?= $controllerClassName ?> extends <?= isset($generator->controllerNs) ? '\\'.$generator->controllerNs.'\\' : '' .'base\\'.$controllerClassName."\n" ?>
 {
 
 }


### PR DESCRIPTION
Produced following code when using yii 2.0.6 advanced template
namespace backend\controllers;
[...]
class UserController extends \\base\UserController

Fix respect's theses circumstance:
namespace backend\controllers;
class UserController extends base\UserController