### PR TITLE
Improve attribute hints generation

### DIFF
--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -201,12 +201,12 @@ class Generator extends \yii\gii\generators\model\Generator
                 'languageCodeColumn' => 'The column name where the language code is stored.',
                 'generateHintsFromComments' => 'This indicates whether the generator should generate attribute hints
                     by using the comments of the corresponding DB columns.',
-            	'useTimestampBehavior' => 'Use <code>TimestampBehavior</code> for tables with column(s) for created at and/or updated at timestamps.',
-            	'createdAtColumn' => 'The column name where the created at timestamp is stored.',
-            	'updatedAtColumn' => 'The column name where the updated at timestamp is stored.',
-            	'useBlameableBehavior' => 'Use <code>BlameableBehavior</code> for tables with column(s) for created by and/or updated by user IDs.',
-           		'createdByColumn' => "The column name where the record creator's user ID is stored.",
-           		'updatedByColumn' => "The column name where the record updater's user ID is stored.",
+                'useTimestampBehavior' => 'Use <code>TimestampBehavior</code> for tables with column(s) for created at and/or updated at timestamps.',
+                'createdAtColumn' => 'The column name where the created at timestamp is stored.',
+                'updatedAtColumn' => 'The column name where the updated at timestamp is stored.',
+                'useBlameableBehavior' => 'Use <code>BlameableBehavior</code> for tables with column(s) for created by and/or updated by user IDs.',
+                'createdByColumn' => "The column name where the record creator's user ID is stored.",
+                'updatedByColumn' => "The column name where the record updater's user ID is stored.",
             ],
             SaveForm::hint()
         );
@@ -372,11 +372,11 @@ class Generator extends \yii\gii\generators\model\Generator
         $hints = [];
 
         if ($this->generateHintsFromComments) {
-			foreach ($table->columns as $column) {
-	            if (!empty($column->comment)) {
-	                $hints[$column->name] = $column->comment;
-	            }
-	        }
+            foreach ($table->columns as $column) {
+                if (!empty($column->comment)) {
+                    $hints[$column->name] = $column->comment;
+                }
+            }
         }
 
         return $hints;
@@ -488,18 +488,18 @@ class Generator extends \yii\gii\generators\model\Generator
      */
     public function generateRules($table)
     {
-    	$columns = [];
-    	foreach ($table->columns as $index => $column) {
-    		$isBlameableCol = ($column->name === $this->createdByColumn || $column->name === $this->updatedByColumn);
-    		$isTimestampCol = ($column->name === $this->createdAtColumn || $column->name === $this->updatedAtColumn);
-    		$removeCol = ($this->useBlameableBehavior && $isBlameableCol)
-    			|| ($this->useTimestampBehavior && $isTimestampCol);
-    		if ($removeCol) {
-    			$columns[$index] = $column;
-    			unset($table->columns[$index]);
-    		}
-    	}
-    	
+        $columns = [];
+        foreach ($table->columns as $index => $column) {
+            $isBlameableCol = ($column->name === $this->createdByColumn || $column->name === $this->updatedByColumn);
+            $isTimestampCol = ($column->name === $this->createdAtColumn || $column->name === $this->updatedAtColumn);
+            $removeCol = ($this->useBlameableBehavior && $isBlameableCol)
+                || ($this->useTimestampBehavior && $isTimestampCol);
+            if ($removeCol) {
+                $columns[$index] = $column;
+                unset($table->columns[$index]);
+            }
+        }
+
         $rules = [];
 
         //for enum fields create rules "in range" for all enum values
@@ -517,7 +517,7 @@ class Generator extends \yii\gii\generators\model\Generator
      
         $rules = array_merge(parent::generateRules($table), $rules);
         $table->columns = array_merge($table->columns, $columns);
-		return $rules;
+        return $rules;
     }
 
     /**
@@ -618,38 +618,38 @@ class Generator extends \yii\gii\generators\model\Generator
     /**
      * @param \yii\db\TableSchema $table the table schema
      * 
-     * @return string[]|null 
+     * @return string[]
      */
     protected function generateBlameable($table)
     {
-    	$createdBy = $table->getColumn($this->createdByColumn) !== null ? $this->createdByColumn : false;
-    	$updatedBy = $table->getColumn($this->updatedByColumn) !== null ? $this->updatedByColumn : false;
+        $createdBy = $table->getColumn($this->createdByColumn) !== null ? $this->createdByColumn : false;
+        $updatedBy = $table->getColumn($this->updatedByColumn) !== null ? $this->updatedByColumn : false;
 
-    	if ($this->useBlameableBehavior && ($createdBy || $updatedBy)) {
-    		return [
-    				'createdByAttribute' => $createdBy,
-    				'updatedByAttribute' => $updatedBy,    				
-    		];
-    	}
-    	return [];
+        if ($this->useBlameableBehavior && ($createdBy || $updatedBy)) {
+            return [
+                'createdByAttribute' => $createdBy,
+                'updatedByAttribute' => $updatedBy,    				
+            ];
+        }
+        return [];
     }
     
     /**
      * @param \yii\db\TableSchema $table the table schema
      * 
-     * @return string[]|null 
+     * @return string[]
      */
     protected function generateTimestamp($table)
     {
-    	$createdAt = $table->getColumn($this->createdAtColumn) !== null ? $this->createdAtColumn : false;
-    	$updatedAt = $table->getColumn($this->updatedAtColumn) !== null ? $this->updatedAtColumn : false;
+        $createdAt = $table->getColumn($this->createdAtColumn) !== null ? $this->createdAtColumn : false;
+        $updatedAt = $table->getColumn($this->updatedAtColumn) !== null ? $this->updatedAtColumn : false;
 
-    	if ($this->useTimestampBehavior && ($createdAt || $updatedAt)) {
-    		return [
-    				'createdAtAttribute' => $createdAt,
-    				'updatedAtAttribute' => $updatedAt,
-    		];
-    	}
-    	return [];
+        if ($this->useTimestampBehavior && ($createdAt || $updatedAt)) {
+            return [
+                'createdAtAttribute' => $createdAt,
+                'updatedAtAttribute' => $updatedAt,
+            ];
+        }
+        return [];
     }
 }

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -180,7 +180,8 @@ class Generator extends \yii\gii\generators\model\Generator
         return array_merge(
             parent::attributeLabels(),
             [
-                'generateModelClass' => 'Generate Model Class',
+            	'generateModelClass' => 'Generate Model Class',
+            	'generateHintsFromComments' => 'Generate Hints from DB Comments',
             ]
         );
     }
@@ -364,22 +365,18 @@ class Generator extends \yii\gii\generators\model\Generator
      * Generates the attribute hints for the specified table.
      * @param \yii\db\TableSchema $table the table schema
      * @return array the generated attribute hints (name => hint)
+     * or an empty array if $this->generateHintsFromComments is false.
      */
     public function generateHints($table)
     {
         $hints = [];
-        foreach ($table->columns as $column) {
-            if ($this->generateHintsFromComments && !empty($column->comment)) {
-                $hints[$column->name] = $column->comment;
-            } elseif (!strcasecmp($column->name, 'id')) {
-                $hints[$column->name] = 'ID';
-            } else {
-                $hint = Inflector::camel2words($column->name);
-                if (!empty($label) && substr_compare($label, ' id', -3, 3, true) === 0) {
-                    $label = substr($label, 0, -3) . ' ID';
-                }
-                $hints[$column->name] = $hint;
-            }
+
+        if ($this->generateHintsFromComments) {
+			foreach ($table->columns as $column) {
+	            if (!empty($column->comment)) {
+	                $hints[$column->name] = $column->comment;
+	            }
+	        }
         }
 
         return $hints;

--- a/src/generators/model/default/model.php
+++ b/src/generators/model/default/model.php
@@ -108,26 +108,26 @@ if(!empty($enum)){
     {
         return [
 <?php if (!empty($blameable)): ?>
-			[
-				'class' => BlameableBehavior::className(),
+            [
+                'class' => BlameableBehavior::className(),
 <?php if ($blameable['createdByAttribute'] !== 'created_by'): ?>
-				'createdByAttribute' => <?= $blameable['createdByAttribute'] ? "'" . $blameable['createdByAttribute'] . "'" : 'false' ?>,
+                'createdByAttribute' => <?= $blameable['createdByAttribute'] ? "'" . $blameable['createdByAttribute'] . "'" : 'false' ?>,
 <?php endif; ?>
 <?php if ($blameable['updatedByAttribute'] !== 'updated_by'): ?>
-				'updatedByAttribute' => <?= $blameable['updatedByAttribute'] ? "'" . $blameable['updatedByAttribute'] . "'" : 'false' ?>,
+                'updatedByAttribute' => <?= $blameable['updatedByAttribute'] ? "'" . $blameable['updatedByAttribute'] . "'" : 'false' ?>,
 <?php endif; ?>
-			],
+            ],
 <?php endif; ?>
 <?php if (!empty($timestamp)): ?>
-			[
-				'class' => TimestampBehavior::className(),
+            [
+                'class' => TimestampBehavior::className(),
 <?php if ($timestamp['createdAtAttribute'] !== 'created_at'): ?>
-				'createdAtAttribute' => <?= $timestamp['createdAtAttribute'] ? "'" . $timestamp['createdAtAttribute'] . "'" : 'false' ?>,
+                'createdAtAttribute' => <?= $timestamp['createdAtAttribute'] ? "'" . $timestamp['createdAtAttribute'] . "'" : 'false' ?>,
 <?php endif; ?>
 <?php if ($timestamp['updatedAtAttribute'] !== 'updated_at'): ?>
-				'updatedAtAttribute' => <?= $timestamp['updatedAtAttribute'] ? "'" . $timestamp['updatedAtAttribute'] . "'" : 'false' ?>,
+                'updatedAtAttribute' => <?= $timestamp['updatedAtAttribute'] ? "'" . $timestamp['updatedAtAttribute'] . "'" : 'false' ?>,
 <?php endif; ?>
-			],
+            ],
 <?php endif; ?>
 <?php if (isset($translation)): ?>
             'translatable' => [
@@ -140,7 +140,7 @@ if(!empty($enum)){
                 'translationAttributes' => [
                     <?= "'" . implode("',\n                    '", $translation['fields']) . "'\n" ?>
                 ],
-			],
+            ],
 <?php endif; ?>
         ];
     }
@@ -172,11 +172,11 @@ if(!empty($enum)){
      */
     public function attributeHints()
     {
-		return array_merge(parent::attributeHints(), [
+        return array_merge(parent::attributeHints(), [
 <?php foreach ($hints as $name => $hint): ?>
             <?= "'$name' => " . $generator->generateString($hint) . ",\n" ?>
 <?php endforeach; ?>
-		]);
+        ]);
     }
 <?php endif; ?>
 <?php foreach ($relations as $name => $relation): ?>

--- a/src/generators/model/default/model.php
+++ b/src/generators/model/default/model.php
@@ -165,20 +165,20 @@ if(!empty($enum)){
 <?php endforeach; ?>
         ];
     }
+<?php if (!empty($hints)): ?>
 
     /**
      * @inheritdoc
      */
     public function attributeHints()
     {
-        return array_merge(
-            parent::attributeHints(),
-            [
+		return array_merge(parent::attributeHints(), [
 <?php foreach ($hints as $name => $hint): ?>
             <?= "'$name' => " . $generator->generateString($hint) . ",\n" ?>
 <?php endforeach; ?>
-            ]);
+		]);
     }
+<?php endif; ?>
 <?php foreach ($relations as $name => $relation): ?>
 
     /**


### PR DESCRIPTION
I have rewritten the `generateHints` method, which was originally copied from the `generateLabels` method.

* The Generator's `generateHints` method now no longer generates attribute hints from column names  (it previously did when there wasn't a column comment). This seems more appropriate to me as by default the labels' text is also generated from column names.

* Setting 'Generate Hints from DB Comments' check-box off now results in hints not being generated.

* Also fixes some inconsistent indentation I introduced in #140.