### PR TITLE
default layout name fix in form.php

### DIFF
--- a/src/generators/crud/form.php
+++ b/src/generators/crud/form.php
@@ -39,7 +39,7 @@ echo $form->field($generator, 'indexWidgetType')->dropDownList(
 echo $form->field($generator, 'formLayout')->dropDownList(
         [
             /* Form Types */
-            'vertical' => 'vertical',
+            'default' => 'full-width',
             'horizontal' => 'horizontal',
             'inline' => 'inline',
         ]


### PR DESCRIPTION
In your form view https://github.com/schmunk42/yii2-giiant/blob/master/src/generators/crud/default/views/_form.php :27 you use yii\bootstrap\ActiveForm, which support only 3 kind of layout: ['default', 'horizontal', 'inline'].
Then if we chek vertical layout - we get error:
yii\base\InvalidConfigException: Invalid layout type: vertical in /home/mix/www/chaos/vendor/yiisoft/yii2-bootstrap/ActiveForm.php:92