### PR TITLE
words should be put outside of <i> tag

### DIFF
--- a/src/generators/crud/default/views/index.php
+++ b/src/generators/crud/default/views/index.php
@@ -149,7 +149,7 @@ echo "?>\n"
                 $items .= <<<PHP
             [
                 'url' => ['{$route}'],
-                'label' => '<i class="glyphicon glyphicon-{$iconType}">&nbsp;' . Yii::t('$generator->modelMessageCategory', '$label') . '</i>',
+                'label' => '<i class="glyphicon glyphicon-{$iconType}"></i> ' . Yii::t('$generator->modelMessageCategory', '$label'),
             ],
                     
 PHP;


### PR DESCRIPTION
because the font family of i tag is glyphicon, put words in <i> tag will make the word look ugly