### PR TITLE
Fix broken URLs on crud relations

### DIFF
--- a/src/commands/BatchController.php
+++ b/src/commands/BatchController.php
@@ -139,7 +139,7 @@ class BatchController extends Controller
     /**
      * @var string route prefix for crud controller actions
      */
-    public $crudPathPrefix = 'crud/';
+    public $crudPathPrefix = '/crud/';
 
     /**
      * @var array list of code provider classes (fully namespaced path required)


### PR DESCRIPTION
Without leading slash, CRUD urls to relations will result in routes like `crud/crud/question/index`, which is wrong. example configs also specify the / prefix on the route, e.g.:
https://github.com/schmunk42/yii2-giiant/blob/b20f277ff994cd5cb49fcd15172cea5ba6aac769/docs/example-config.php#L47
