### PR TITLE
use relation property instead of relation getter

### DIFF
--- a/src/generators/crud/providers/core/RelationProvider.php
+++ b/src/generators/crud/providers/core/RelationProvider.php
@@ -134,18 +134,18 @@ EOS;
             $routeIndex = $this->generator->createRelationRoute($relation, 'index');
 
             $modelClass = $this->generator->modelClass;
-            $relationGetter = 'get'.(new ModelGenerator())->generateRelationName(
+            $relationProperty = lcfirst((new ModelGenerator())->generateRelationName(
                     [$relation],
                     $modelClass::getTableSchema(),
                     $column->name,
                     $relation->multiple
-                ).'()';
+                ));
             $relationModel = new $relation->modelClass();
             $relationModelName = StringHelper::basename($modelClass);
             $pks = $relationModel->primaryKey();
             $paramArrayItems = '';
             foreach ($pks as $attr) {
-                $paramArrayItems .= "'{$attr}' => \$model->{$relationGetter}->one()->{$attr},";
+                $paramArrayItems .= "'{$attr}' => \$model->{$relationProperty}->{$attr},";
             }
             $attachArrayItems = "'{$relationModelName}'=>['{$column->name}' => \$model->{$column->name}]";
 
@@ -155,9 +155,9 @@ EOS;
 [
     'format' => 'html',
     'attribute' => '$column->name',
-    'value' => (\$model->{$relationGetter}->one() ? 
+    'value' => (\$model->{$relationProperty} ? 
         Html::a('<i class="glyphicon glyphicon-list"></i>', ['{$routeIndex}']).' '.
-        Html::a('<i class="glyphicon glyphicon-circle-arrow-right"></i> '.\$model->{$relationGetter}->one()->{$title}, ['{$route}', {$paramArrayItems}]).' '.
+        Html::a('<i class="glyphicon glyphicon-circle-arrow-right"></i> '.\$model->{$relationProperty}->{$title}, ['{$route}', {$paramArrayItems}]).' '.
         Html::a('<i class="glyphicon glyphicon-paperclip"></i>', ['{$routeAttach}', {$attachArrayItems}])
         : 
         '<span class="label label-warning">?</span>'),
@@ -206,12 +206,12 @@ EOS;
             $route = $this->generator->createRelationRoute($relation, 'view');
             $method = __METHOD__;
             $modelClass = $this->generator->modelClass;
-            $relationGetter = 'get'.(new ModelGenerator())->generateRelationName(
+            $relationProperty = lcfirst((new ModelGenerator())->generateRelationName(
                     [$relation],
                     $modelClass::getTableSchema(),
                     $column->name,
                     $relation->multiple
-                ).'()';
+                ));
             $relationModel = new $relation->modelClass();
             $pks = $relationModel->primaryKey();
             $paramArrayItems = '';
@@ -226,7 +226,7 @@ EOS;
     'class' => yii\\grid\\DataColumn::className(),
     'attribute' => '{$column->name}',
     'value' => function (\$model) {
-        if (\$rel = \$model->{$relationGetter}->one()) {
+        if (\$rel = \$model->{$relationProperty}) {
             return Html::a(\$rel->{$title}, ['{$route}', {$paramArrayItems}], ['data-pjax' => 0]);
         } else {
             return '';


### PR DESCRIPTION
When using the relation getter to access a model's relations, a db query is executed even if the relation has already been loaded to the model.

Switch to using the relation property, which will make the db query if the relation has not been retrieved yet, else it will simply use the previously retrieved relation data.