### PR TITLE
fixed ModelTrait::getModelRelations if no types are given

### DIFF
--- a/src/generators/crud/ModelTrait.php
+++ b/src/generators/crud/ModelTrait.php
@@ -116,8 +116,8 @@ trait ModelTrait
                     } else {
                         $relationType = 'has_many';
                     }
-
-                    if (in_array($relationType, $types)) {
+                    // if types is empty, return all types -> no filter
+                    if ((count($types) == 0) || in_array($relationType, $types)) {
                         $name = $modelGenerator->generateRelationName(
                             [$relation],
                             $model->getTableSchema(),


### PR DESCRIPTION
if no types to filter are given to ModelTrait::getModelRelations we should return all types.

Otherwise giiant will generate empty relation selects e.g. in generators/crud/default/views/index.php
