### PR TITLE
include basic attributes from model generator into BatchController

### DIFF
--- a/src/commands/BatchController.php
+++ b/src/commands/BatchController.php
@@ -34,6 +34,31 @@ class BatchController extends Controller
     public $useTimestampBehavior = true;
 
     /**
+     * @var string the name of the column where the user who updated the entry is stored
+     */
+    public $createdAtColumn = 'created_at';
+
+    /**
+     * @var string the name of the column where the user who updated the entry is stored
+     */
+    public $updatedAtColumn = 'updated_at';
+
+    /**
+     * @var bool whether or not to use BlameableBehavior
+     */
+    public $useBlameableBehavior = true;
+
+    /**
+     * @var string the name of the column where the user who created the entry is stored
+     */
+    public $createdByColumn = 'created_by';
+
+    /**
+     * @var string the name of the column where the user who updated the entry is stored
+     */
+    public $updatedByColumn = 'updated_by';
+
+    /**
      * @var string the name of the table containing the translations. {{table}} will be replaced with the value in
      *             "Table Name" field
      */
@@ -223,10 +248,15 @@ class BatchController extends Controller
             [
                 'template',
                 'overwrite',
-                'useTranslatableBehavior',
                 'useTimestampBehavior',
+                'createdAtColumn',
+                'updatedAtColumn',
+                'useTranslatableBehavior',
                 'languageTableName',
                 'languageCodeColumn',
+                'useBlameableBehavior',
+                'createdByColumn',
+                'updatedByColumn',
                 'extendedModels',
                 'enableI18N',
                 'messageCategory',
@@ -311,10 +341,15 @@ class BatchController extends Controller
             $params = [
                 'interactive' => $this->interactive,
                 'overwrite' => $this->overwrite,
-                'useTranslatableBehavior' => $this->useTranslatableBehavior,
                 'useTimestampBehavior' => $this->useTimestampBehavior,
+                'createdAtColumn' => $this->createdAtColumn,
+                'updatedAtColumn' => $this->updatedAtColumn,
+                'useTranslatableBehavior' => $this->useTranslatableBehavior,
                 'languageTableName' => $this->languageTableName,
                 'languageCodeColumn' => $this->languageCodeColumn,
+                'useBlameableBehavior' => $this->useBlameableBehavior,
+                'createdByColumn' => $this->createdByColumn,
+                'updatedByColumn' => $this->updatedByColumn,
                 'template' => $this->template,
                 'ns' => $this->modelNamespace,
                 'db' => $this->modelDb,

--- a/src/commands/BatchController.php
+++ b/src/commands/BatchController.php
@@ -120,6 +120,11 @@ class BatchController extends Controller
     public $modelRemoveDuplicateRelations = false;
 
     /**
+     * @var
+     */
+    public $modelGenerateRelations = ModelGenerator::RELATIONS_ALL;
+
+    /**
      * @var bool whether the strings will be generated using `Yii::t()` or normal strings
      */
     public $enableI18N = true;
@@ -269,6 +274,7 @@ class BatchController extends Controller
                 'modelBaseTraits',
                 'modelBaseClassSuffix',
                 'modelRemoveDuplicateRelations',
+                'modelGenerateRelations',
                 'modelGenerateQuery',
                 'modelQueryNamespace',
                 'modelQueryBaseClass',
@@ -366,6 +372,7 @@ class BatchController extends Controller
                 'baseClass' => $this->modelBaseClass,
                 'baseTraits' => $this->modelBaseTraits,
                 'removeDuplicateRelations' => $this->modelRemoveDuplicateRelations,
+                'generateRelations' => $this->modelGenerateRelations,
                 'tableNameMap' => $this->tableNameMap,
                 'generateQuery' => $this->modelGenerateQuery,
                 'queryNs' => $this->modelQueryNamespace,

--- a/src/generators/model/default/model.php
+++ b/src/generators/model/default/model.php
@@ -84,7 +84,16 @@ if(!empty($enum)){
     {
         return '<?= $tableName ?>';
     }
+<?php if ($generator->db !== 'db'): ?>
 
+    /**
+     * @return \yii\db\Connection the database connection used by this AR class.
+     */
+    public static function getDb()
+    {
+        return Yii::$app->get('<?= $generator->db ?>');
+    }
+<?php endif; ?>
 <?php if (isset($translation) || !empty($blameable) || !empty($timestamp)): ?>
 
     /**


### PR DESCRIPTION
Current BatchController can not be used to set `createdAtColumn` and `updatedAtColumn` for `useTimestampBehavior`, as well as `createdByColumn` and `updatedByColumn` for `useBlameableBehavior`.

I just simply add those properties from `schmunk42\giiant\generators\model\Generator` into `schmunk42\giiant\commands\BatchController`