### PR TITLE
Close DB after each model generation

### DIFF
--- a/src/commands/BatchController.php
+++ b/src/commands/BatchController.php
@@ -403,6 +403,7 @@ class BatchController extends Controller
             $app = \Yii::$app;
             $temp = new \yii\console\Application($this->appConfig);
             $temp->runAction(ltrim($route, '/'), $params);
+            $temp->get($this->modelDb)->close();
             unset($temp);
             \Yii::$app = $app;
             \Yii::$app->log->logger->flush(true);


### PR DESCRIPTION
Each new app instance will open a new database connection, when generating a lot of models this causes a "Too many connections" error.
This PR closes the database of the temp app before unloading it (which does not automatically closes the db connection).