### PR TITLE
Fix XSS Vulnerability in CRUD views generated

### DIFF
--- a/src/generators/crud/default/views/create.php
+++ b/src/generators/crud/default/views/create.php
@@ -34,7 +34,7 @@ $this->params['breadcrumbs'][] = $this->title;
         <?= "<?= Yii::t('{$generator->modelMessageCategory}', '{$modelName}') ?>\n" ?>
         <small>
             <?php $label = StringHelper::basename($generator->modelClass); ?>
-            <?= '<?= $model->'.$generator->getModelNameAttribute($generator->modelClass)." ?>\n" ?>
+            <?= '<?= Html::encode($model->'.$generator->getModelNameAttribute($generator->modelClass).") ?>\n" ?>
         </small>
     </h1>
 

--- a/src/generators/crud/default/views/update.php
+++ b/src/generators/crud/default/views/update.php
@@ -37,7 +37,7 @@ $this->params['breadcrumbs'][] = <?= $generator->generateString('Edit') ?>;
 
         <small>
             <?php $label = StringHelper::basename($generator->modelClass); ?>
-            <?= '<?= $model->'.$generator->getModelNameAttribute($generator->modelClass)." ?>\n" ?>
+            <?= '<?= Html::encode($model->'.$generator->getModelNameAttribute($generator->modelClass).") ?>\n" ?>
         </small>
     </h1>
 

--- a/src/generators/crud/default/views/view.php
+++ b/src/generators/crud/default/views/view.php
@@ -63,7 +63,7 @@ $this->params['breadcrumbs'][] = <?= $generator->generateString('View') ?>;
     <h1>
         <?= "<?= Yii::t('{$generator->modelMessageCategory}', '{$modelName}') ?>\n" ?>
         <small>
-            <?= '<?= $model->'.$generator->getModelNameAttribute($generator->modelClass)." ?>\n" ?>
+            <?= '<?= Html::encode($model->'.$generator->getModelNameAttribute($generator->modelClass).") ?>\n" ?>
         </small>
     </h1>
 
@@ -140,7 +140,7 @@ $this->params['breadcrumbs'][] = <?= $generator->generateString('View') ?>;
 
     $items = <<<EOS
 [
-    'label'   => '<b class=""># '.\$model->{$model->primaryKey()[0]}.'</b>',
+    'label'   => '<b class=""># '.Html::encode(\$model->{$model->primaryKey()[0]}).'</b>',
     'content' => \$this->blocks['{$generator->modelClass}'],
     'active'  => true,
 ],


### PR DESCRIPTION
Added Html::encode in CRUD views default templates to fixing XSS Vulnerability when using string in primary key.
XSS Attack
![image](https://user-images.githubusercontent.com/10207513/40987499-0d19ece4-68bf-11e8-833d-3802bd9fcd63.png)

Fixed
![image](https://user-images.githubusercontent.com/10207513/40987959-45ac986c-68c0-11e8-8eda-1f42d3c69d46.png)

