### PR TITLE
add baseClassPrefix to model generator.

### DIFF
--- a/src/commands/BatchController.php
+++ b/src/commands/BatchController.php
@@ -100,6 +100,11 @@ class BatchController extends Controller
     public $modelNamespace = 'common\\models';
 
     /**
+     * @var string suffix to prepend to the base model, setting "Base" will result in a model named "BasePost"
+     */
+    public $modelBaseClassPrefix = '';
+
+    /**
      * @var string suffix to append to the base model, setting "Base" will result in a model named "PostBase"
      */
     public $modelBaseClassSuffix = '';
@@ -280,6 +285,7 @@ class BatchController extends Controller
                 'modelNamespace',
                 'modelBaseClass',
                 'modelBaseTraits',
+                'modelBaseClassPrefix',
                 'modelBaseClassSuffix',
                 'modelRemoveDuplicateRelations',
                 'modelGenerateRelations',
@@ -383,6 +389,7 @@ class BatchController extends Controller
                 'singularEntities' => $this->singularEntities,
                 'messageCategory' => $this->modelMessageCategory,
                 'generateModelClass' => $this->extendedModels,
+                'baseClassPrefix' => $this->modelBaseClassPrefix,
                 'baseClassSuffix' => $this->modelBaseClassSuffix,
                 'modelClass' => isset($this->tableNameMap[$table]) ?
                     $this->tableNameMap[$table] :
@@ -505,3 +512,4 @@ class BatchController extends Controller
         @mkdir($dir);
     }
 }
+

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -7,11 +7,11 @@
  */
 namespace schmunk42\giiant\generators\model;
 
+use schmunk42\giiant\helpers\SaveForm;
 use Yii;
 use yii\gii\CodeFile;
 use yii\helpers\Inflector;
 use yii\helpers\StringHelper;
-use schmunk42\giiant\helpers\SaveForm;
 
 /**
  * This generator will generate one or multiple ActiveRecord classes for the specified database table.
@@ -82,6 +82,11 @@ class Generator extends \yii\gii\generators\model\Generator
      * @var string the column name where the language code is stored
      */
     public $languageCodeColumn = 'language';
+
+    /**
+     * @var string prefix to prepend to the base model, setting "Base" will result in a model named "BasePost"
+     */
+    public $baseClassPrefix = '';
 
     /**
      * @var string suffix to append to the base model, setting "Base" will result in a model named "PostBase"
@@ -275,8 +280,8 @@ class Generator extends \yii\gii\generators\model\Generator
 
             $files[] = new CodeFile(
                 Yii::getAlias(
-                    '@'.str_replace('\\', '/', $this->ns)
-                ).'/base/'.$className.$this->baseClassSuffix.'.php',
+                    '@' . str_replace('\\', '/', $this->ns)
+                ) . '/base/' . $this->baseClassPrefix . $className . $this->baseClassSuffix . '.php',
                 $this->render('model.php', $params)
             );
 
@@ -682,3 +687,4 @@ class Generator extends \yii\gii\generators\model\Generator
         return [];
     }
 }
+

--- a/src/generators/test/Generator.php
+++ b/src/generators/test/Generator.php
@@ -158,7 +158,7 @@ class Generator extends \schmunk42\giiant\generators\model\Generator
             ];
 
             $files[] = new CodeFile(
-                Yii::getAlias('@app/..'.$this->codeceptionPath.str_replace('\\', '/', $this->ns)).'/'.$className.$this->baseClassSuffix.'UnitTest.php',
+                Yii::getAlias('@app/..'.$this->codeceptionPath.str_replace('\\', '/', $this->ns)).'/'.$this->baseClassPrefix.$className.$this->baseClassSuffix.'UnitTest.php',
                 $this->render('unit.php', $params)
             );
         }
@@ -166,3 +166,4 @@ class Generator extends \schmunk42\giiant\generators\model\Generator
         return $files;
     }
 }
+


### PR DESCRIPTION
Currently there has already been baseClassSurfix, but the IDE's auto
completion function will prompt both Model and ModelBase with Model name
as prefix. So I regard naming the base model class BaseModel better for
some people.