### PR TITLE
Correct message category for view action button

### DIFF
--- a/src/generators/crud/default/views/index.php
+++ b/src/generators/crud/default/views/index.php
@@ -204,8 +204,8 @@ PHP;
             'buttons' => [
                 'view' => function (\$url, \$model, \$key) {
                     \$options = [
-                        'title' => Yii::t('cruds', 'View'),
-                        'aria-label' => Yii::t('cruds', 'View'),
+                        'title' => Yii::t('{$generator->messageCategory}', 'View'),
+                        'aria-label' => Yii::t('{$generator->messageCategory}', 'View'),
                         'data-pjax' => '0',
                     ];
                     return Html::a('<span class="glyphicon glyphicon-file"></span>', \$url, \$options);


### PR DESCRIPTION
The "View" action button in default crud index template had static 'crud' message category.