### PR TITLE
error with php 7.3

### DIFF
--- a/src/generators/crud/ModelTrait.php
+++ b/src/generators/crud/ModelTrait.php
@@ -39,7 +39,6 @@ trait ModelTrait
                         return $name;
                         break;
                     default:
-                        continue;
                         break;
                 }
             }


### PR DESCRIPTION
PHP Warning 'yii\base\ErrorException' with message '"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?'