### PR TITLE
update composer.json for yii-gii new version and newer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "dmstr/yii2-db": "*",
         "friendsofphp/php-cs-fixer": "1.* || 2.*",
         "yiisoft/yii2": "~2.0.13",
-        "yiisoft/yii2-gii": "~2.0.6"
+        "yiisoft/yii2-gii": "2.*"
     },
     "require-dev": {
         "codeception/codeception": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "dmstr/yii2-db": "*",
         "friendsofphp/php-cs-fixer": "1.* || 2.*",
         "yiisoft/yii2": "~2.0.13",
-        "yiisoft/yii2-gii": "2.*"
+        "yiisoft/yii2-gii": "~2.0.6 || ~2.1.0"
     },
     "require-dev": {
         "codeception/codeception": "^2.2",


### PR DESCRIPTION
fix error:
```
Problem 1
    - Can only install one of: yiisoft/yii2-gii[2.0.x-dev, 2.1.0].
    - Can only install one of: yiisoft/yii2-gii[2.0.x-dev, 2.1.0].
    - schmunk42/yii2-giiant dev-master requires yiisoft/yii2-gii ~2.0.6 -> satisfiable by yiisoft/yii2-gii[2.0.x-dev].
    - Installation request for schmunk42/yii2-giiant dev-master -> satisfiable by schmunk42/yii2-giiant[dev-master].
    - Installation request for yiisoft/yii2-gii ~2.1.0 -> satisfiable by yiisoft/yii2-gii[2.1.0].
```