### PR TITLE
Fixed multi-table model json generation

### DIFF
--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -249,8 +249,8 @@ class Generator extends \yii\gii\generators\model\Generator
         $db = $this->getDbConnection();
 
         foreach ($this->getTableNames() as $tableName) {
-			$oldClassName = $this->modelClass;
-			$oldTableName = $this->tableName;
+            $oldClassName = $this->modelClass;
+            $oldTableName = $this->tableName;
             list($relations, $translations) = array_values($this->extractTranslations($tableName, $relations));
 //var_dump($relations,$tableName);exit;
             $className = $this->modelClass === '' || php_sapi_name() === 'cli'

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -249,8 +249,6 @@ class Generator extends \yii\gii\generators\model\Generator
         $db = $this->getDbConnection();
 
         foreach ($this->getTableNames() as $tableName) {
-            $oldClassName = $this->modelClass;
-            $oldTableName = $this->tableName;
             list($relations, $translations) = array_values($this->extractTranslations($tableName, $relations));
 //var_dump($relations,$tableName);exit;
             $className = $this->modelClass === '' || php_sapi_name() === 'cli'
@@ -319,12 +317,11 @@ class Generator extends \yii\gii\generators\model\Generator
             $formDataFile = StringHelper::dirname($formDataDir)
                     .'/gii'
                     .'/'.$tableName.$suffix.'.json';
-            $this->tableName = $tableName;
-            $this->modelClass = $className;
-            $formData = json_encode(SaveForm::getFormAttributesValues($this, $this->formAttributes()));
+            $generatorForm = (clone $this);
+            $generatorForm->tableName = $tableName;
+			$generatorForm->modelClass = $className;
+            $formData = json_encode(SaveForm::getFormAttributesValues($generatorForm, $this->formAttributes()));
             $files[] = new CodeFile($formDataFile, $formData);
-            $this->modelClass = $oldClassName;
-            $this->tableName = $oldTableName;
         }
 
         return $files;

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -249,6 +249,8 @@ class Generator extends \yii\gii\generators\model\Generator
         $db = $this->getDbConnection();
 
         foreach ($this->getTableNames() as $tableName) {
+			$oldClassName = $this->modelClass;
+			$oldTableName = $this->tableName;
             list($relations, $translations) = array_values($this->extractTranslations($tableName, $relations));
 //var_dump($relations,$tableName);exit;
             $className = $this->modelClass === '' || php_sapi_name() === 'cli'
@@ -317,9 +319,12 @@ class Generator extends \yii\gii\generators\model\Generator
             $formDataFile = StringHelper::dirname($formDataDir)
                     .'/gii'
                     .'/'.$tableName.$suffix.'.json';
-
+            $this->tableName = $tableName;
+            $this->modelClass = $className;
             $formData = json_encode(SaveForm::getFormAttributesValues($this, $this->formAttributes()));
             $files[] = new CodeFile($formDataFile, $formData);
+            $this->modelClass = $oldClassName;
+            $this->tableName = $oldTableName;
         }
 
         return $files;

--- a/src/helpers/SaveForm.php
+++ b/src/helpers/SaveForm.php
@@ -5,132 +5,132 @@ namespace schmunk42\giiant\helpers;
 use yii\helpers\StringHelper;
 
 class SaveForm {
-	public static $savedFormList = false;
+    public static $savedFormList = false;
 
-	public static function hint() {
-		return ['savedForm' => 'Choose saved form ad load it data to form.'];
-	}
+    public static function hint() {
+        return ['savedForm' => 'Choose saved form ad load it data to form.'];
+    }
 
-	/**
-	 * get form attributes values.
-	 */
-	public static function getFormAttributesValues($generator, $attributes) {
-		$values = [];
-		foreach ($attributes as $name) {
-			$values[strtolower($name)] = [
-				'value' => $generator->$name,
-				'name' => $name,
-			];
-		}
+    /**
+     * get form attributes values.
+     */
+    public static function getFormAttributesValues($generator, $attributes) {
+        $values = [];
+        foreach ($attributes as $name) {
+            $values[strtolower($name)] = [
+                'value' => $generator->$name,
+                'name' => $name,
+            ];
+        }
 
-		return $values;
-	}
+        return $values;
+    }
 
-	/**
-	 * walk through all modules, gii directories and collect Giant crud generator saved forms.
-	 *
-	 * @param $generatorName
-	 * @return array|bool
-	 * @throws \ReflectionException
-	 */
-	public static function loadSavedForms($generatorName)
-	{
-		$suffix = str_replace(' ', '', $generatorName);
+    /**
+     * walk through all modules, gii directories and collect Giant crud generator saved forms.
+     *
+     * @param $generatorName
+     * @return array|bool
+     * @throws \ReflectionException
+     */
+    public static function loadSavedForms($generatorName)
+    {
+        $suffix = str_replace(' ', '', $generatorName);
 
-		if (self::$savedFormList) {
-			return self::$savedFormList;
-		}
+        if (self::$savedFormList) {
+            return self::$savedFormList;
+        }
 
-		/*
-		 * get all possible gii directories with out validation on existing
-		 */
-		$forms = [];
-		self::buildJson(\Yii::getAlias('@app/gii'), $forms, $suffix, 'app');
-		if ($commonGiiDir = \Yii::getAlias('@common/gii', false)) {
-			self::buildJson($commonGiiDir, $forms, $suffix,  'common');
-		}
-		foreach (\Yii::$app->modules as $moduleId => $module) {
-			/*
-			 * get module base path
-			 */
-			if (method_exists($module, 'getBasePath')) {
-				$basePath = $module->getBasePath();
-			} else {
-				if(!class_exists($module['class'])){
-					\Yii::warning('Invalid class definition for module ' . $moduleId);
-					continue;
-				}
-				$reflector = new \ReflectionClass($module['class']);
-				$basePath = StringHelper::dirname($reflector->getFileName());
-			}
-			$basePath .= '/gii';
+        /*
+         * get all possible gii directories with out validation on existing
+         */
+        $forms = [];
+        self::buildJson(\Yii::getAlias('@app/gii'), $forms, $suffix, 'app');
+        if ($commonGiiDir = \Yii::getAlias('@common/gii', false)) {
+            self::buildJson($commonGiiDir, $forms, $suffix,  'common');
+        }
+        foreach (\Yii::$app->modules as $moduleId => $module) {
+            /*
+             * get module base path
+             */
+            if (method_exists($module, 'getBasePath')) {
+                $basePath = $module->getBasePath();
+            } else {
+                if(!class_exists($module['class'])){
+                    \Yii::warning('Invalid class definition for module ' . $moduleId);
+                    continue;
+                }
+                $reflector = new \ReflectionClass($module['class']);
+                $basePath = StringHelper::dirname($reflector->getFileName());
+            }
+            $basePath .= '/gii';
 
-			self::buildJson($basePath, $forms, $suffix, $moduleId);
-		}
+            self::buildJson($basePath, $forms, $suffix, $moduleId);
+        }
 
-		return self::$savedFormList = $forms;
-	}
+        return self::$savedFormList = $forms;
+    }
 
-	/**
-	 * from all gii directories collect forms
-	 * @param string $path
-	 * @param string $moduleId
-	 * @param array $forms
-	 * @param string $suffix
-	 */
-	protected static function buildJson($path, &$forms, $suffix, $moduleId = NULL) {
-		/*
-		 * search in module gii directory all forms json files
-		 * with required suffix
-		 */
-		if (!file_exists($path)) {
-			return;
-		}
+    /**
+     * from all gii directories collect forms
+     * @param string $path
+     * @param string $moduleId
+     * @param array $forms
+     * @param string $suffix
+     */
+    protected static function buildJson($path, &$forms, $suffix, $moduleId = NULL) {
+        /*
+         * search in module gii directory all forms json files
+         * with required suffix
+         */
+        if (!file_exists($path)) {
+            return;
+        }
 
-		$files = scandir($path);
-		foreach ($files as $file) {
-			if (!preg_match('#' . $suffix . '\.json$#', $file)) {
-				continue;
-			}
-			$name = preg_replace('#' . $suffix . '\.json$#', '', $file);
-			$forms[$moduleId . $name] = [
-				'jsonData' => file_get_contents($path . '/' . $file),
-				'label' => $moduleId . ' - ' . $name,
-			];
-		}
-	}
+        $files = scandir($path);
+        foreach ($files as $file) {
+            if (!preg_match('#' . $suffix . '\.json$#', $file)) {
+                continue;
+            }
+            $name = preg_replace('#' . $suffix . '\.json$#', '', $file);
+            $forms[$moduleId . $name] = [
+                'jsonData' => file_get_contents($path . '/' . $file),
+                'label' => $moduleId . ' - ' . $name,
+            ];
+        }
+    }
 
-	/**
-	 * get array for form field "Saved form" data.
-	 *
-	 * @return array
-	 */
-	public static function getSavedFormsListbox($generatorName) {
-		$r = ['0' => ' - '];
-		foreach (self::loadSavedForms($generatorName) as $k => $row) {
-			$r[$k] = $row['label'];
-		}
+    /**
+     * get array for form field "Saved form" data.
+     *
+     * @return array
+     */
+    public static function getSavedFormsListbox($generatorName) {
+        $r = ['0' => ' - '];
+        foreach (self::loadSavedForms($generatorName) as $k => $row) {
+            $r[$k] = $row['label'];
+        }
 
-		return $r;
-	}
+        return $r;
+    }
 
-	/**
-	 * creata js statement for seting to variable savedFormas array with all forms and it data in json format.
-	 *
-	 * @return string
-	 */
-	public static function getSavedFormsJs($generatorName) {
-		$js = [];
+    /**
+     * creata js statement for seting to variable savedFormas array with all forms and it data in json format.
+     *
+     * @return string
+     */
+    public static function getSavedFormsJs($generatorName) {
+        $js = [];
 
-		foreach (self::loadSavedForms($generatorName) as $k => $row) {
-			$js[] = $k . ":'" . $row['jsonData'] . "'";
-		}
+        foreach (self::loadSavedForms($generatorName) as $k => $row) {
+            $js[] = $k . ":'" . $row['jsonData'] . "'";
+        }
 
-		return 'var savedForms = {' . str_replace('\\', '\\\\', implode(',', $js)) . '};';
-	}
+        return 'var savedForms = {' . str_replace('\\', '\\\\', implode(',', $js)) . '};';
+    }
 
-	public static function jsFillForm() {
-		return '
+    public static function jsFillForm() {
+        return '
     function fillForm(id){
         if (id=="0") return;
 
@@ -176,5 +176,5 @@ class SaveForm {
         }    
     }
         ';
-	}
+    }
 }

--- a/src/helpers/SaveForm.php
+++ b/src/helpers/SaveForm.php
@@ -4,17 +4,20 @@ namespace schmunk42\giiant\helpers;
 
 use yii\helpers\StringHelper;
 
-class SaveForm {
+class SaveForm
+{
     public static $savedFormList = false;
 
-    public static function hint() {
+    public static function hint()
+    {
         return ['savedForm' => 'Choose saved form ad load it data to form.'];
     }
 
     /**
      * get form attributes values.
      */
-    public static function getFormAttributesValues($generator, $attributes) {
+    public static function getFormAttributesValues($generator, $attributes)
+    {
         $values = [];
         foreach ($attributes as $name) {
             $values[strtolower($name)] = [
@@ -27,7 +30,7 @@ class SaveForm {
     }
 
     /**
-     * walk through all modules, gii directories and collect Giant crud generator saved forms.
+     * walk through all modules gii directories and collect Giant crud generator saved forms.
      *
      * @param $generatorName
      * @return array|bool
@@ -78,7 +81,8 @@ class SaveForm {
      * @param array $forms
      * @param string $suffix
      */
-    protected static function buildJson($path, &$forms, $suffix, $moduleId = NULL) {
+    protected static function buildJson($path, &$forms, $suffix, $moduleId = NULL)
+    {
         /*
          * search in module gii directory all forms json files
          * with required suffix
@@ -105,7 +109,8 @@ class SaveForm {
      *
      * @return array
      */
-    public static function getSavedFormsListbox($generatorName) {
+    public static function getSavedFormsListbox($generatorName)
+    {
         $r = ['0' => ' - '];
         foreach (self::loadSavedForms($generatorName) as $k => $row) {
             $r[$k] = $row['label'];
@@ -119,17 +124,19 @@ class SaveForm {
      *
      * @return string
      */
-    public static function getSavedFormsJs($generatorName) {
+    public static function getSavedFormsJs($generatorName)
+    {
         $js = [];
 
         foreach (self::loadSavedForms($generatorName) as $k => $row) {
-            $js[] = $k . ":'" . $row['jsonData'] . "'";
+            $js[] = $k.":'".$row['jsonData']."'";
         }
 
-        return 'var savedForms = {' . str_replace('\\', '\\\\', implode(',', $js)) . '};';
+        return 'var savedForms = {'.str_replace('\\', '\\\\', implode(',', $js)).'};';
     }
 
-    public static function jsFillForm() {
+    public static function jsFillForm()
+    {
         return '
     function fillForm(id){
         if (id=="0") return;
@@ -172,7 +179,7 @@ class SaveForm {
             if (jQuery("#" + fieldId).is("input") || jQuery("#" + fieldId).is("select")){
                 jQuery("#" + fieldId).val(formData[filedName]["value"]).trigger("input");
                 continue;
-            }
+            }    
         }    
     }
         ';


### PR DESCRIPTION
When using `table*` model generation the generated json files kept the `*` in the table name instead of their respective table name (if this was just one json file saving the multi-table format this would of been fine). I've went in and fixed the generation model's tablename and class while it's creating the JSON file data so that each JSON file created has the proper variables now to be re-used. I've also fixed the labels for the dropdown so they actually say the correct module/path that they are stored in, before it was just using the last value from a for each loop.