### PR TITLE
make creation of the class name between model and crud generator consistent

### DIFF
--- a/src/commands/BatchController.php
+++ b/src/commands/BatchController.php
@@ -447,9 +447,14 @@ class BatchController extends Controller
         $this->createDirectoryFromNamespace($this->crudSearchModelNamespace);
 
         foreach ($this->tables as $table) {
-            $table = str_replace($this->tablePrefix, '', $table);
-            $name = isset($this->tableNameMap[$table]) ? $this->tableNameMap[$table] :
-                $this->modelGenerator->generateClassName($table);
+
+            if (isset($this->tableNameMap[$table])) {
+                $tmp_name = $this->tableNameMap[$table];
+            } else {
+                $tmp_name = str_replace($this->tablePrefix, '', $table);
+            }
+            $name = $this->modelGenerator->generateClassName($tmp_name);
+
             $params = [
                 'interactive' => $this->interactive,
                 'overwrite' => $this->overwrite,


### PR DESCRIPTION
If prefix and map are defined together, you had to define the TableNames in the map once with and once without prefix.

This PR makes creation of the class name between model and crud generator more consistent so that the definition in the map is only necessary once (with prefix)