### PR TITLE
Removed deprecated code and not needed

### DIFF
--- a/src/generators/model/default/model.php
+++ b/src/generators/model/default/model.php
@@ -72,9 +72,6 @@ if(!empty($enum)){
             echo '    const ' . $enum_value['const_name'] . ' = \'' . $enum_value['value'] . '\';' . PHP_EOL;
         }
     }
-?>
-    var $enum_labels = false;
-<?php
 }
 ?>
     /**


### PR DESCRIPTION
> Note: The PHP 4 method of declaring a variable with the var keyword is still supported for compatibility reasons (as a synonym for the public keyword). In PHP 5 before 5.1.3, its usage would generate an E_STRICT warning.
https://www.php.net/manual/en/language.oop5.visibility.php
