### PR TITLE
Improved model generation performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+### 0.12.1
+
+ - Improved model generation performance (see`modelCacheRelationsData`)
+ 
 ### 0.12.0
 
  - Added support for `modelGenerateJunctionRelationMode`

--- a/docs/25-cli-commands.md
+++ b/docs/25-cli-commands.md
@@ -149,6 +149,9 @@ OPTIONS
 
 --removeDuplicateRelations: boolean, 0 or 1 (defaults to 0)
 
+--cacheRelationsData: boolean, 0 or 1 (defaults to 1)
+  Should relation data be cached when generating multiple models
+
 --savedForm: string
   Choose saved form ad load it data to form.
 

--- a/src/commands/BatchController.php
+++ b/src/commands/BatchController.php
@@ -7,6 +7,7 @@ use schmunk42\giiant\generators\model\Generator as ModelGenerator;
 use yii\console\Controller;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Inflector;
+use Yii;
 
 /**
  * @author Tobias Munk <schmunk@usrbin.de>
@@ -133,6 +134,11 @@ class BatchController extends Controller
      * @var
      */
     public $modelRemoveDuplicateRelations = false;
+
+    /**
+     * @var
+     */
+    public $modelCacheRelationsData = true;
 
     /**
      * @var
@@ -321,6 +327,7 @@ class BatchController extends Controller
                 'modelBaseClassPrefix',
                 'modelBaseClassSuffix',
                 'modelRemoveDuplicateRelations',
+                'modelCacheRelationsData',
                 'modelGenerateRelations',
                 'modelGenerateJunctionRelationMode',
                 'modelGenerateQuery',
@@ -404,6 +411,8 @@ class BatchController extends Controller
      */
     public function actionModels()
     {
+        $startTime = microtime(true);
+
         // create models
         foreach ($this->tables as $table) {
             $params = [
@@ -436,6 +445,7 @@ class BatchController extends Controller
                 'baseClass' => $this->modelBaseClass,
                 'baseTraits' => $this->modelBaseTraits,
                 'removeDuplicateRelations' => $this->modelRemoveDuplicateRelations,
+                'cacheRelationsData' => $this->modelCacheRelationsData,
                 'generateRelations' => $this->modelGenerateRelations,
                 'generateJunctionRelationMode' => $this->modelGenerateJunctionRelationMode,
                 'tableNameMap' => $this->tableNameMap,
@@ -455,6 +465,8 @@ class BatchController extends Controller
             \Yii::$app = $app;
             \Yii::$app->log->logger->flush(true);
         }
+
+        Yii::debug('Generated models in ' . round(microtime(true) - $startTime, 3) . ' seconds.', __METHOD__);
     }
 
     /**

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -106,6 +106,9 @@ class Generator extends \yii\gii\generators\model\Generator
 
     public $removeDuplicateRelations = false;
 
+    /** @var bool Cache relations data between model generation */
+    public $cacheRelationsData = true;
+
     /**
      * @var bool This indicates whether the generator should generate attribute hints by using the comments of the corresponding DB columns
      */
@@ -119,6 +122,8 @@ class Generator extends \yii\gii\generators\model\Generator
     public $messageCategory = 'models';
 
     protected $classNames2;
+
+    protected static $_relationsCache = null;
 
     /**
      * {@inheritdoc}
@@ -253,7 +258,16 @@ class Generator extends \yii\gii\generators\model\Generator
     public function generate()
     {
         $files = [];
-        $relations = $this->generateRelations();
+
+        if ($this->cacheRelationsData) {
+            if (static::$_relationsCache === null) {
+                static::$_relationsCache = $this->generateRelations();
+            }
+            $relations = static::$_relationsCache;
+        } else {
+            $relations = $this->generateRelations();
+        }
+
         $db = $this->getDbConnection();
 
         foreach ($this->getTableNames() as $tableName) {


### PR DESCRIPTION
When generating models for many tables (and relations) the generation can take quite some time.
The majority of the time is spent on the `generateRelations` function. Since this function returns the same data for each table this data can be cached.

Test data: 224 tables
| cacheRelationsData  | Duration |
| ------------- | ------------- |
| false  | 1:00:30  |
| true  | 0:01:12  |

In this case the models were generated more than 50x faster with caching enabled.

As far as I can see it is fully backwards compatible. But I've added the `modelCacheRelationsData` option to disable the cache just in case.
