### PR TITLE
Fixed closing of db when set via DI

### DIFF
--- a/src/commands/BatchController.php
+++ b/src/commands/BatchController.php
@@ -450,7 +450,11 @@ class BatchController extends Controller
             $app = \Yii::$app;
             $temp = new \yii\console\Application($this->appConfig);
             $temp->runAction(ltrim($route, '/'), $params);
-            $temp->get($this->modelDb)->close();
+            if (\Yii::$container->has($this->modelDb)) {
+                \Yii::$container->get($this->modelDb)->close();
+            } else {
+                $temp->get($this->modelDb)->close();
+            }
             unset($temp);
             \Yii::$app = $app;
             \Yii::$app->log->logger->flush(true);


### PR DESCRIPTION
When the db connection name is specified via DI configuration (and therefore not a component of the app) the connection could not be found.
This pull requests fixes this by first checking the DI container similar to `schmunk42\giiant\generators\model\Generator::getDbConnection()`.