### PR TITLE
Moved "friendsofphp/php-cs-fixer" to "require-dev" in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "dmstr/yii2-bootstrap": "^0.1.2 || ^0.2.1",
         "dmstr/yii2-helpers": "*",
         "dmstr/yii2-db": "*",
-        "friendsofphp/php-cs-fixer": "1.* || 2.*",
         "yiisoft/yii2": "~2.0.13",
         "yiisoft/yii2-gii": "^2.2.0"
     },
@@ -25,6 +24,7 @@
         "codeception/codeception": "^2.2",
         "codeception/specify": "^0.4",
         "dmstr/yii2-web": "^0.4.2 || ^1.0.0",
+        "friendsofphp/php-cs-fixer": "1.* || 2.*",
         "yiisoft/yii2-faker": "2.*",
         "rmrevin/yii2-fontawesome": "2.*",
         "insolita/yii2-adminlte-widgets": "1.1.*"


### PR DESCRIPTION
Currently the "friendsofphp/php-cs-fixer" is specified in composer's "require" section. This blocks the use of php-cs-fixer version 3 in other projects.
Unless it's used in the code somewhere (I couldn't fiend any place) it should be specified in "require-dev".