### PR TITLE
Fix getting name attribute on cruds/view

### DIFF
--- a/src/generators/crud/default/views/view.php
+++ b/src/generators/crud/default/views/view.php
@@ -45,7 +45,7 @@ $copyParams = $model->attributes;
 
 $this->title = Yii::t('<?= $generator->modelMessageCategory ?>', '<?= $modelName ?>');
 $this->params['breadcrumbs'][] = ['label' => Yii::t('<?= $generator->modelMessageCategory ?>.plural', '<?= $modelName ?>'), 'url' => ['index']];
-$this->params['breadcrumbs'][] = ['label' => (string)$model-><?= $generator->getNameAttribute() ?>, 'url' => ['view', <?= $urlParams ?>]];
+$this->params['breadcrumbs'][] = ['label' => (string)$model-><?= $generator->getModelNameAttribute($model)?>, 'url' => ['view', <?= $urlParams ?>]];
 $this->params['breadcrumbs'][] = <?= $generator->generateString('View') ?>;
 ?>
 <div class="giiant-crud <?= Inflector::camel2id(StringHelper::basename($generator->modelClass), '-', true) ?>-view">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41924972/145788057-b78f55a7-a83a-41b7-8558-4299a374257e.png)
If model has not default name attribute (not 'name', or 'title') (see yii2-gii yii\gii\generators\crud\Generator:221)- in breadcrumps will be used its ID attribute instead of getLabel() method (see yii2-giiant\src\generators\crud\default\views\view.php 

By the way in a header of view's page use getLabel() method
![image](https://user-images.githubusercontent.com/41924972/145788370-7d173633-8446-429e-bef4-5239dbc36c5f.png)

So I changed $generator->getNameAttribute() (gii module method) with $generator->genModelNameAttribute() (giiant crud RelationTrait method)
After changing generation looks like
![image](https://user-images.githubusercontent.com/41924972/145789195-24224d16-7e33-458a-8ed5-029e94045cbe.png)
As you can see generator started using getLabel() method of model to get main name attribute

![image](https://user-images.githubusercontent.com/41924972/145789392-fd86dc61-8230-467d-b21f-cd987dd452cf.png)