### PR TITLE
Removed duplicate 'template' key

### DIFF
--- a/src/commands/BatchController.php
+++ b/src/commands/BatchController.php
@@ -509,7 +509,6 @@ class BatchController extends Controller
                 'overwriteSearchModelClass' => $this->crudOverwriteSearchModelClass,
                 'overwriteRestControllerClass' => $this->crudOverwriteRestControllerClass,
                 'overwriteControllerClass' => $this->crudOverwriteControllerClass,
-                'template' => $this->template,
                 'modelClass' => $this->modelNamespace . '\\' . $name,
                 'searchModelClass' => $this->crudSearchModelNamespace . '\\' . $name . $this->crudSearchModelSuffix,
                 'controllerNs' => $this->crudControllerNamespace,


### PR DESCRIPTION
The `$params` contains a duplicate array key 'template':
https://github.com/schmunk42/yii2-giiant/blob/master/src/commands/BatchController.php#L512
https://github.com/schmunk42/yii2-giiant/blob/master/src/commands/BatchController.php#L532

This PR removes the first one.