### PR TITLE
Allow configuration of the Application class

### DIFF
--- a/src/commands/BatchController.php
+++ b/src/commands/BatchController.php
@@ -16,6 +16,11 @@ use Yii;
 class BatchController extends Controller
 {
     /**
+     * @var string Console application class
+     */
+    public $applicationClass = 'yii\\console\\Application';
+
+    /**
      * @var string the generator template name
      */
     public $template = 'default';
@@ -469,7 +474,7 @@ class BatchController extends Controller
             $route = 'gii/giiant-model';
 
             $app = \Yii::$app;
-            $temp = new Application($this->appConfig);
+            $temp = new $this->applicationClass($this->appConfig);
             $temp->runAction(ltrim($route, '/'), $params);
             $this->closeTempAppConnections($temp);
             unset($temp);
@@ -539,7 +544,7 @@ class BatchController extends Controller
             ];
             $route = 'gii/giiant-crud';
             $app = \Yii::$app;
-            $temp = new Application($this->appConfig);
+            $temp = new $this->applicationClass($this->appConfig);
             $temp->runAction(ltrim($route, '/'), $params);
             $this->closeTempAppConnections($temp);
             unset($temp);


### PR DESCRIPTION
Currently the Application class is fixed in the BatchController. When a custom Application is used the configuration might not compatible with the default `yii\console\Application`.
This PR allows configuration of the Application class so that a custom class can be specified.