### PR TITLE
Translateable behavior properties

### DIFF
--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -619,7 +619,7 @@ class Generator extends \yii\gii\generators\model\Generator
         if ($this->useTranslatableBehavior and isset($relations[$langTableName], $relations[$tableName])) {
             $db = $this->getDbConnection();
             $langTableSchema = $db->getTableSchema($langTableName);
-            $langTableColumns = $langTableSchema->getColumnNames();
+            $langTableColumns = $langTableSchema->columns;
             $langTableKeys = array_merge(
                 $langTableSchema->primaryKey,
                 array_map(
@@ -639,13 +639,13 @@ class Generator extends \yii\gii\generators\model\Generator
 
                     // collect fields which are not PK, FK nor language code
                     $fields = [];
-                    foreach ($langTableColumns as $columnName) {
-                        if (!in_array($columnName, $langTableKeys) and strcasecmp(
-                                $columnName,
+                    foreach ($langTableColumns as $column) {
+                        if (!in_array($column->name, $langTableKeys) and strcasecmp(
+                                $column->name,
                                 $this->languageCodeColumn
                             ) !== 0
                         ) {
-                            $fields[] = $columnName;
+                            $fields[$column->name] = $column->type;
                         }
                     }
 
@@ -711,4 +711,3 @@ class Generator extends \yii\gii\generators\model\Generator
         return [];
     }
 }
-

--- a/src/generators/model/default/model.php
+++ b/src/generators/model/default/model.php
@@ -39,9 +39,17 @@ use <?php echo $timestamp['timestampBehaviorClass']; ?>;
 /**
  * This is the base-model class for table "<?= $tableName ?>".
  *
-<?php foreach ($tableSchema->columns as $column): ?>
+<?php foreach ($tableSchema->columns as   $column): ?>
  * @property <?= "{$column->phpType} \${$column->name}\n" ?>
 <?php endforeach; ?>
+<?php
+if (isset($translation)) {
+    echo " * \n * Properties from TranslateableBehavior \n";
+    foreach ($translation['fields'] as $name => $type) {
+        echo " * @property $type \$$name \n";
+    }
+}
+?>
 <?php if (!empty($relations)): ?>
  *
 <?php foreach ($relations as $name => $relation): ?>
@@ -131,7 +139,7 @@ if(!empty($enum)){
                 'languageField' => '<?= $generator->languageCodeColumn ?>',
 <?php endif; ?>
                 'translationAttributes' => [
-                    <?= "'" . implode("',\n                    '", $translation['fields']) . "'\n" ?>
+                    <?= "'" . implode("',\n                    '", array_keys($translation['fields'])) . "'\n" ?>
                 ],
             ],
 <?php endif; ?>

--- a/src/generators/model/default/model.php
+++ b/src/generators/model/default/model.php
@@ -39,7 +39,7 @@ use <?php echo $timestamp['timestampBehaviorClass']; ?>;
 /**
  * This is the base-model class for table "<?= $tableName ?>".
  *
-<?php foreach ($tableSchema->columns as   $column): ?>
+<?php foreach ($tableSchema->columns as $column): ?>
  * @property <?= "{$column->phpType} \${$column->name}\n" ?>
 <?php endforeach; ?>
 <?php


### PR DESCRIPTION
When opt-in the `Use Translatable Behavior` checkbox, some additional code is generated to the model.  
The main point of the Translatable Behavior is bring the attributes from "language tables" to the main model via magic properties. 
The generator already have the list of attributes, so it would be great if it could generate PHPDOC for the relevant properties to achieve auto-completion for IDE

I tried to make the changes, it works for me, hope I didn't break anything. It should be quite small but helpful change.