### PR TITLE
Fix for yiisoft/yii2-gii 2.2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "dmstr/yii2-db": "*",
         "friendsofphp/php-cs-fixer": "1.* || 2.* || 3.*",
         "yiisoft/yii2": "~2.0.13",
-        "yiisoft/yii2-gii": "^2.2.0"
+        "yiisoft/yii2-gii": "^2.2.7"
     },
     "require-dev": {
         "codeception/codeception": "^2.2",

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -552,7 +552,7 @@ class Generator extends \yii\gii\generators\model\Generator
             }
 
             $column_camel_name = str_replace(' ', '', ucwords(implode(' ', explode('_', $column->name))));
-            $enum[$column->name]['func_opts_name'] = 'opts' . $column_camel_name;
+            $enum[$column->name]['funcOptsName'] = 'opts' . $column_camel_name;
             $enum[$column->name]['func_get_label_name'] = 'get' . $column_camel_name . 'ValueLabel';
             $enum[$column->name]['values'] = [];
 

--- a/src/generators/model/Generator.php
+++ b/src/generators/model/Generator.php
@@ -553,7 +553,7 @@ class Generator extends \yii\gii\generators\model\Generator
 
             $column_camel_name = str_replace(' ', '', ucwords(implode(' ', explode('_', $column->name))));
             $enum[$column->name]['funcOptsName'] = 'opts' . $column_camel_name;
-            $enum[$column->name]['func_get_label_name'] = 'get' . $column_camel_name . 'ValueLabel';
+            $enum[$column->name]['funcGetLabelName'] = 'get' . $column_camel_name . 'ValueLabel';
             $enum[$column->name]['values'] = [];
 
             $enum_values = explode(',', substr($column->dbType, 4, strlen($column->dbType) - 1));
@@ -570,7 +570,7 @@ class Generator extends \yii\gii\generators\model\Generator
 
                 $enum[$column->name]['values'][] = [
                     'value' => $value,
-                    'const_name' => $const_name,
+                    'constName' => $const_name,
                     'label' => $label,
                 ];
             }
@@ -619,7 +619,7 @@ class Generator extends \yii\gii\generators\model\Generator
         foreach ($enum as $field_name => $field_details) {
             $ea = array();
             foreach ($field_details['values'] as $field_enum_values) {
-                $ea[] = 'self::' . $field_enum_values['const_name'];
+                $ea[] = 'self::' . $field_enum_values['constName'];
             }
             $rules[] = "['" . $field_name . "', 'in', 'range' => [\n                    " . implode(
                     ",\n                    ",

--- a/src/generators/model/default/model.php
+++ b/src/generators/model/default/model.php
@@ -273,7 +273,7 @@ $behaviors['translation'] = [
      * @return string
      */
     public static function <?php echo $column_data['func_get_label_name']?>($value){
-        $labels = self::<?php echo $column_data['func_opts_name']?>();
+        $labels = self::<?php echo $column_data['funcOptsName']?>();
         if(isset($labels[$value])){
             return $labels[$value];
         }
@@ -284,7 +284,7 @@ $behaviors['translation'] = [
      * column <?php echo $column_name?> ENUM value labels
      * @return array
      */
-    public static function <?php echo $column_data['func_opts_name']?>()
+    public static function <?php echo $column_data['funcOptsName']?>()
     {
         return [
 <?php

--- a/src/generators/model/default/model.php
+++ b/src/generators/model/default/model.php
@@ -76,7 +76,7 @@ if(!empty($enum)){
 <?php
     foreach($enum as $column_name => $column_data){
         foreach ($column_data['values'] as $enum_value){
-            echo '    const ' . $enum_value['const_name'] . ' = \'' . $enum_value['value'] . '\';' . PHP_EOL;
+            echo '    const ' . $enum_value['constName'] . ' = \'' . $enum_value['value'] . '\';' . PHP_EOL;
         }
     }
 }
@@ -272,7 +272,7 @@ $behaviors['translation'] = [
      * @param string $value
      * @return string
      */
-    public static function <?php echo $column_data['func_get_label_name']?>($value){
+    public static function <?php echo $column_data['funcGetLabelName']?>($value){
         $labels = self::<?php echo $column_data['funcOptsName']?>();
         if(isset($labels[$value])){
             return $labels[$value];
@@ -289,7 +289,7 @@ $behaviors['translation'] = [
         return [
 <?php
         foreach($column_data['values'] as $k => $value){
-            echo '            '.'self::' . $value['const_name'] . ' => ' . $generator->generateString($value['label']) . ",\n";
+            echo '            '.'self::' . $value['constName'] . ' => ' . $generator->generateString($value['label']) . ",\n";
         }
 ?>
         ];


### PR DESCRIPTION
When generating a table with an enum field, the current giiant version(1.0.3) is not compatible with gii version 2.2.7 installed because the enum handling was included in the Gii through a pull request. 

The problem is that this was implemented a little differently than it was originally implemented in giiant. see [gii implementation](https://github.com/yiisoft/yii2-gii/commit/c7f7533b8c8b1d9dbb882db16b83b0f2dcffd83a) vs [original giiant implementation](https://github.com/schmunk42/yii2-giiant/commit/d0178326bf9e7fc9e7022c9dce43e42590a6d833)

This PR uses the naming from gii and adapts the corresponding places in the model template and raises the minimum giia constraint to 2.2.7

